### PR TITLE
restore-config: defer migration until the system is configured

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -66,6 +66,6 @@ event_actions($event,
 
 $event = "post-restore-config";
 event_actions($event,
-     'nethserver-getmail-migrate-ns6' => '60'
+     'nethserver-getmail-migrate-ns6' => '80'
 );
 


### PR DESCRIPTION
Avoid failure if ``getmail`` db is not initialized.
